### PR TITLE
Set puppet minimum version_requirement to 3.8.7

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,13 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=3.2.0 <5.0.0"
+      "version_requirement": ">=4.6.0 <5.0.0"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 3.8.7 < 5.0.0"
     }
   ]
 }


### PR DESCRIPTION
Also bump minimum version dependencies needed for Puppet 4