### PR TITLE
BREAKING: Drop Puppet 3 support. Pin gems to ruby 1.9 compatible versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,3 @@
 fixtures:
-  repositories:
-    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib.git
   symlinks:
     report_hipchat: "#{source_dir}"
-

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ A Puppet report handler for sending notifications of Puppet runs to [HipChat](ht
 
 * `hipchat >= 0.12.0`
 * `puppet >= 4.6.1`
-
-Note: Puppet 3.x should generally work with the plugin, but requires the parameter `install_hc_gem => false`, and then
-you will need to take care to install the hipchat gem appropriately.
+* `puppetserver >= 2`
 
 #### Obtaining Hipchat Auth Token
 For the room in which you want to receive puppet notifications, add a new BYO Integration. This will return an example url: `https://example.hipchat.com/v2/room/123456789/notification?auth_token=WzP0dc4oEESuSmF2WJT23GtL5mili9uXof73M48S`
@@ -85,9 +83,8 @@ class { 'report_hipchat':
 ```
 
 ### Provider
-* `puppetserver_gem` used for opensource and pe puppetserver requires [puppetlabs-pe_gem](https://forge.puppet.com/puppetlabs/puppetserver_gem)
-* `pe_gem` used for PE puppet master 3.x requires [puppetlabs-pe_gem](https://forge.puppet.com/puppetlabs/pe_gem)
-* `gem` used for opensource puppet-master 
+
+Deprecated.  Only `puppetserver_gem` is supported.
 
 ### Configure the report in puppet.conf
 ```puppet

--- a/lib/puppet/reports/hipchat.rb
+++ b/lib/puppet/reports/hipchat.rb
@@ -8,7 +8,7 @@ rescue LoadError
 end
 
 if Gem::Version.new(Puppet.version) < Gem::Version.new('4.0.0')
-  Puppet.warning 'Puppet 3.x support is depricated, upgrade to puppet 4'
+  Puppet.error 'Puppet 3.x is not supported in this version of the hipchat report processor'
 end
 
 Puppet::Reports.register_report(:hipchat) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,10 +20,6 @@ class report_hipchat (
   $api_version    = $::report_hipchat::params::api_version,
   $proxy          = $::report_hipchat::params::proxy,
 ) inherits report_hipchat::params {
-  if versioncmp($::puppetversion, '4.0.0') < 0 {
-    notify{'Puppet 3.x support is depricated, upgrade to puppet 4': }
-  }
-
   file { $config_file:
     ensure  => file,
     owner   => $owner,
@@ -33,9 +29,22 @@ class report_hipchat (
   }
 
   if $install_hc_gem {
+    $install_options = $proxy ? {
+      undef   => undef,
+      default => ['--http-proxy', $proxy],
+    }
+
+    package { 'httparty':
+      ensure          => '~> 0.14.0',
+      provider        => $provider,
+      install_options => $install_options,
+    }
+
     package { $package_name:
-      ensure   => installed,
-      provider => $provider,
+      ensure          => '~> 1.5.0',
+      provider        => $provider,
+      install_options => $install_options,
+      require         => Package['httparty'],
     }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,29 +4,14 @@
 #
 class report_hipchat::params {
 
-  $package_name = 'hipchat'
-  $puppetboard  = undef
-  $dashboard    = undef
-  $api_version  = 'v1'
-  $proxy        = undef
-
-  if str2bool($::is_pe) {
-    $install_hc_gem  = true
-    $puppetconf_path = '/etc/puppetlabs/puppet'
-    $provider        = 'pe_gem'
-    $owner           = 'pe-puppet'
-    $group           = 'pe-puppet'
-  } elsif ($::puppetversion) and (versioncmp('4.0.0', $::puppetversion) < 1) {
-    $puppetconf_path = '/etc/puppetlabs/puppet'
-    $install_hc_gem  = false
-    $provider        = undef
-    $owner           = 'puppet'
-    $group           = 'puppet'
-  } else {
-    $install_hc_gem  = true
-    $puppetconf_path = '/etc/puppet'
-    $provider        = 'gem'
-    $owner           = 'puppet'
-    $group           = 'puppet'
-  }
+  $package_name    = 'hipchat'
+  $puppetboard     = undef
+  $dashboard       = undef
+  $api_version     = 'v1'
+  $proxy           = undef
+  $provider        = 'puppetserver_gem'
+  $puppetconf_path = '/etc/puppetlabs/puppet'
+  $owner           = 'puppet'
+  $group           = 'puppet'
+  $install_hc_gem  = true
 }

--- a/metadata.json
+++ b/metadata.json
@@ -44,14 +44,14 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 <5.0.0"
+      "name": "puppetlabs/puppetserver_gem",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.6.1 < 5.0.0"
+      "version_requirement": ">= 4.6.1 < 6.0.0"
     }
   ]
 }

--- a/spec/acceptance/hipchat_spec.rb
+++ b/spec/acceptance/hipchat_spec.rb
@@ -53,7 +53,6 @@ describe 'puppet-hipchat' do
           statuses       => ['all', 'testing'],
           install_hc_gem => true,
           provider       => 'puppetserver_gem',
-          proxy          => 'http://myproxy.com:80',
           notify         => Service['puppetserver'],
         }
         EOS

--- a/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
+++ b/spec/acceptance/nodesets/docker/ubuntu-16.04.yml
@@ -10,7 +10,7 @@ HOSTS:
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
-      - 'apt-get install -y net-tools wget'
+      - 'apt-get install -y net-tools wget locales apt-transport-https'
       - 'locale-gen en_US.UTF-8'
 CONFIG:
   trace_limit: 200

--- a/spec/classes/puppet_init_spec.rb
+++ b/spec/classes/puppet_init_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 describe 'report_hipchat' do
   let(:facts) do
     {
-      is_pe:          false,
-      puppetversion: '3.0.0'
+      puppetversion: '4.6.1'
     }
   end
 
@@ -16,17 +15,17 @@ describe 'report_hipchat' do
         server:  'myserver'
       }
     end
+
     it { is_expected.to contain_class('report_hipchat') }
     it { is_expected.to contain_class('report_hipchat::params') }
-    it { is_expected.to contain_notify('Puppet 3.x support is depricated, upgrade to puppet 4') }
-    it { is_expected.to contain_package('hipchat').with(provider: 'gem') }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_api: mykey}) }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_room: myroom}) }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_server: myserver}) }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_api_version: v1\n}) }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').without_content(%r{:hipchat_proxy:}) }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').without_content(%r{:hipchat_puppetboard:}) }
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').without_content(%r{:hipchat_dashboard:}) }
+    it { is_expected.to contain_package('hipchat').with(provider: 'puppetserver_gem') }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_api: mykey}) }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_room: myroom}) }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_server: myserver}) }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_api_version: v1\n}) }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').without_content(%r{:hipchat_proxy:}) }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').without_content(%r{:hipchat_puppetboard:}) }
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').without_content(%r{:hipchat_dashboard:}) }
   end
 
   describe 'use api version 2' do
@@ -38,7 +37,8 @@ describe 'report_hipchat' do
         api_version: 'v2'
       }
     end
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_api_version: v2}) }
+
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_api_version: v2}) }
   end
 
   describe 'specify file location' do
@@ -49,6 +49,7 @@ describe 'report_hipchat' do
         config_file: '/tmp/foo'
       }
     end
+
     it { is_expected.to contain_file('/tmp/foo') }
   end
 
@@ -60,40 +61,8 @@ describe 'report_hipchat' do
         install_hc_gem: false
       }
     end
-    it { is_expected.not_to contain_package('hipchat') }
-  end
 
-  describe 'on pe' do
-    let(:facts) do
-      {
-        is_pe: true
-      }
-    end
-    let(:params) do
-      {
-        api_key: 'mykey',
-        room:    'myroom'
-      }
-    end
-    it { is_expected.to contain_package('hipchat').with_provider('pe_gem') }
-    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml') }
-  end
-
-  describe 'on puppet 4' do
-    let(:facts) do
-      {
-        is_pe:         false,
-        puppetversion: '4.0.0'
-      }
-    end
-    let(:params) do
-      {
-        api_key: 'mykey',
-        room:    'myroom'
-      }
-    end
     it { is_expected.not_to contain_package('hipchat') }
-    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml') }
   end
 
   describe 'with proxy' do
@@ -105,7 +74,8 @@ describe 'report_hipchat' do
         proxy:   'myproxy'
       }
     end
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_proxy: myproxy\n}) }
+
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_proxy: myproxy\n}) }
   end
 
   describe 'with puppetboard' do
@@ -117,7 +87,8 @@ describe 'report_hipchat' do
         puppetboard: 'mypuppetboard'
       }
     end
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_puppetboard: mypuppetboard\n}) }
+
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_puppetboard: mypuppetboard\n}) }
   end
 
   describe 'with dashboard' do
@@ -129,6 +100,7 @@ describe 'report_hipchat' do
         dashboard: 'mydashboard'
       }
     end
-    it { is_expected.to contain_file('/etc/puppet/hipchat.yaml').with_content(%r{:hipchat_dashboard: mydashboard\n}) }
+
+    it { is_expected.to contain_file('/etc/puppetlabs/puppet/hipchat.yaml').with_content(%r{:hipchat_dashboard: mydashboard\n}) }
   end
 end


### PR DESCRIPTION
Drop puppet 3 support and only support puppetserver systems.
The majority of puppetservers will be running in ruby 1.9 mode.